### PR TITLE
Chemical Curiosities music magic compatibility patch

### DIFF
--- a/data/moremusicalmagic/songs_chemical_curiosities.lua
+++ b/data/moremusicalmagic/songs_chemical_curiosities.lua
@@ -1,0 +1,8 @@
+if ModIsEnabled("Hydroxide") then
+  ocarina_songs["tinker"] = { "a2", "f", "d", "b", "a", "c", "e", "gsharp", "a2" }
+  ocarina_funcs["tinker"] = function()
+    local x, y = EntityGetTransform( entity_id )
+    EntityLoad( "mods/Hydroxide/files/entities/misc/tinkersong.xml", x, y )
+    GamePrintImportant( "The Gods sing along to your song", "Can you hear them?" )
+  end
+end

--- a/init.lua
+++ b/init.lua
@@ -1870,6 +1870,8 @@ if ModTextFileGetContent("data/moremusicalmagic/musicmagic.lua") == nil then
 end
 ModLuaFileAppend("data/moremusicalmagic/musicmagic.lua", "data/moremusicalmagic/songs_default.lua")
 ModLuaFileAppend("data/moremusicalmagic/musicmagic.lua", "data/moremusicalmagic/songs_apotheosis.lua")
+--Chemical curiosities patch - requires Apotheosis to be loaded after Chemical Curiosities.
+ModLuaFileAppend("data/moremusicalmagic/musicmagic.lua", "data/moremusicalmagic/songs_chemical_curiosities.lua")
 
 
 --Set Custom Seed (And Check for Secret Seeds)


### PR DESCRIPTION
Saw that music magic of Apotheosis and Chemical Curiosities (CC) don't quite get along.  So here is a small patch.
Basically I copied the code for the music magic (L222 in CC's `data/scripts/magic/ocarina.lua`) here.
Requires Apotheosis to be loaded after CC.