### PR TITLE
defer to original draw_action return instead of reimplementing it

### DIFF
--- a/files/gun.lua
+++ b/files/gun.lua
@@ -31,22 +31,11 @@ end
 
 ---@diagnostic disable-next-line: lowercase-global
 function draw_action(...)
-	apo_state.old.draw_action(...)
+	local ret = apo_state.old.draw_action(...)
 	-- Force recharge if learning orb
 	if apo_state.min_reload then current_reload_time = math.max(apo_state.min_reload, current_reload_time) end
 
-	if reflecting then  return  end
-
-	if action_mana_required > mana then
-		OnNotEnoughManaForAction()
-		table.insert( discarded, action )
-		return false -- <------------------------------------------ RETURNS
-	end
-
-	if action.uses_remaining == 0 then
-		table.insert( discarded, action )
-		return false -- <------------------------------------------ RETURNS
-	end
+	return ret
 end
 
 function BeginProjectile(entity_filename)


### PR DESCRIPTION
was excited to try [a3ce177](https://github.com/Conga0/Apotheosis/commit/a3ce177f6afc83b13accbd8482c3ea133cd93364) as black holes past a spent one failing to get modified was really bugging me, but that change appears to do wacky stuff (starting bomb wand would just spit out everything at once, lots of modifiers and stuff got skipped, ???)

anyway, this seems to bring us back to vanilla expectations but still enable the recharge-forcing behaviour of knowledge orb that i *think* you're going for? lmk